### PR TITLE
feat: add production health check endpoints for K8s/OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,15 +47,17 @@ WORKDIR $HOME
 
 # Create necessary directories with proper permissions for OpenShift
 # OpenShift runs with random UIDs, so we need world-writable directories
-RUN mkdir -p /tmp/nginx_client_body /tmp/nginx_proxy /tmp/nginx_fastcgi /tmp/nginx_uwsgi /tmp/nginx_scgi /home/geostudio/errors && \
+RUN mkdir -p /tmp/nginx_client_body /tmp/nginx_proxy /tmp/nginx_fastcgi /tmp/nginx_uwsgi /tmp/nginx_scgi /home/geostudio/errors /home/geostudio/health && \
     chmod -R 777 /tmp/nginx_client_body /tmp/nginx_proxy /tmp/nginx_fastcgi /tmp/nginx_uwsgi /tmp/nginx_scgi && \
-    chown -R 1001:0 /home/geostudio/errors && \
-    chmod -R g=u /home/geostudio/errors
+    chown -R 1001:0 /home/geostudio/errors /home/geostudio/health && \
+    chmod -R g=u /home/geostudio/errors /home/geostudio/health
 
 COPY --chown=1001:1001 --from=build /usr/src/app/docker-entrypoint.sh docker-entrypoint.sh
 COPY --chown=1001:1001 --from=build /usr/src/app/deploy/start_nginx.sh start_nginx.sh
 COPY --chown=1001:1001 --from=build /usr/src/app/deploy/config/nginx.conf nginx.conf
 COPY --chown=1001:1001 --from=build /usr/src/app/deploy/config/404.html errors/404.html
+COPY --chown=1001:1001 --from=build /usr/src/app/deploy/config/health/liveness.html health/liveness.html
+COPY --chown=1001:1001 --from=build /usr/src/app/deploy/config/health/readiness.html health/readiness.html
 COPY --chown=1001:1001 --from=build /usr/src/app/deploy/config/env.json env.json
 # Set permissions for OpenShift compatibility (group 0 = root group)
 RUN chown -R 1001:0 $HOME && \

--- a/deploy/config/health/liveness.html
+++ b/deploy/config/health/liveness.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Liveness Check</title>
+</head>
+<body>
+    <h1>OK</h1>
+</body>
+</html>

--- a/deploy/config/health/readiness.html
+++ b/deploy/config/health/readiness.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Readiness Check</title>
+</head>
+<body>
+    <h1>OK</h1>
+</body>
+</html>

--- a/deploy/config/nginx.conf
+++ b/deploy/config/nginx.conf
@@ -67,6 +67,21 @@ http {
         root /home/geostudio/srv;
         index index.html;
 
+        # Health check endpoints for Kubernetes/OpenShift
+        # Liveness probe - checks if the container is alive
+        location /healthz {
+            access_log off;
+            add_header Content-Type text/html;
+            alias /home/geostudio/health/liveness.html;
+        }
+
+        # Readiness probe - checks if the application is ready to serve traffic
+        location /ready {
+            access_log off;
+            add_header Content-Type text/html;
+            alias /home/geostudio/health/readiness.html;
+        }
+
         # Custom 404 error page
         error_page 404 /404.html;
         location = /404.html {


### PR DESCRIPTION
## Summary

Implements liveness and readiness health check endpoints for Kubernetes/OpenShift deployments.
- **`/healthz`** - Liveness probe endpoint
  - Returns 200 OK when container is alive
  - Used by K8s to determine if container needs restart
  
- **`/ready`** - Readiness probe endpoint
  - Returns 200 OK when application is ready for traffic
  - Used by K8s to control service endpoint routing
  
- `deploy/config/nginx.conf` - Added health check location blocks
- `Dockerfile` - Updated to include health check files

## Related Issue (optional)

<!-- e.g. Fixes #123 -->

## How to test this PR?

<!-- Describe how you tested your changes: -->
<!-- Include commands if relevant: -->

```bash
# Test liveness endpoint
curl http://localhost:8090/healthz

# Test readiness endpoint
curl http://localhost:8090/ready
```

## Screenshots / Logs (optional)

<!-- Attach any relevant logs or screenshots. -->

## Checklist

- [x] This PR targets the main branch
- [ ] I have added or updated relevant docs.
- [x] I have not included any secrets or credentials.
- [x] Linting and formatting checks pass.
